### PR TITLE
release 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build Mod
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.4.0-beta
+      MODKIT_VERSION: 0.9.4.3-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
   build-mod:
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.4.0-beta
+      MODKIT_VERSION: 0.9.4.3-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/EcoCivicsImportExportMod/CivicBundle.cs
+++ b/EcoCivicsImportExportMod/CivicBundle.cs
@@ -174,6 +174,21 @@ namespace Eco.Mods.CivicsImpExp
             => Civics.Select(c => c.AsReference).Contains(reference)
             || AllInlineObjects.Select(c => c.AsReference).Contains(reference);
 
+        public IEnumerable<string> ApplyMigrations()
+        {
+            var migrationReport = new List<string>();
+            var migrator = new Migrations.MigratorV1();
+            foreach (var obj in Civics)
+            {
+                if (migrator.ShouldMigrate(obj.Data))
+                {
+                    migrationReport.Add($"Applying migrations for {obj.AsReference}...");
+                    migrator.ApplyMigration(obj.Data, migrationReport);
+                }
+            }
+            return migrationReport;
+        }
+
         public IEnumerable<IHasID> ImportAll()
         {
             var importContext = new ImportContext();

--- a/EcoCivicsImportExportMod/CivicsImpExpPlugin.cs
+++ b/EcoCivicsImportExportMod/CivicsImpExpPlugin.cs
@@ -261,6 +261,23 @@ namespace Eco.Mods.CivicsImpExp
                 }
             }
 
+            // Perform migrations
+            IEnumerable<string> migrationReport;
+            try
+            {
+                migrationReport = bundle.ApplyMigrations();
+            }
+            catch (Exception ex)
+            {
+                user.Player.Msg(new LocString($"Failed to perform migrations on civic: {ex.Message}"));
+                Logger.Error(ex.ToString());
+                return;
+            }
+            if (migrationReport.Count() > 0)
+            {
+                user.Player.Msg(new LocString($"Some migrations were performed:\n{string.Join("\n", migrationReport)}"));
+            }
+
             // Import the objects from the bundle
             IEnumerable<IHasID> importedObjects;
             try

--- a/EcoCivicsImportExportMod/Migrations/ExternalMigratorV1.cs
+++ b/EcoCivicsImportExportMod/Migrations/ExternalMigratorV1.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Newtonsoft.Json.Linq;
+
+namespace Eco.Mods.CivicsImpExp.Migrations
+{
+    public class ExternalMigratorV1 : ICivicsImpExpMigratorV1
+    {
+        private readonly object migratorObj;
+        private readonly MethodInfo shouldMigrateMethod;
+        private readonly MethodInfo applyMigrationMethod;
+
+        public ExternalMigratorV1(object migratorObj)
+        {
+            this.migratorObj = migratorObj;
+            shouldMigrateMethod = migratorObj.GetType().GetMethod("ShouldMigrate", BindingFlags.Public | BindingFlags.Instance);
+            applyMigrationMethod = migratorObj.GetType().GetMethod("ApplyMigration", BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        public bool ShouldMigrate(JObject obj)
+            => (bool)shouldMigrateMethod.Invoke(migratorObj, new object[] { obj });
+
+        public bool ApplyMigration(JObject obj, IList<string> outMigrationReport)
+            => (bool)applyMigrationMethod.Invoke(migratorObj, new object[] { obj, outMigrationReport });
+
+        public override string ToString()
+            => $"ExternalMigratorV1({migratorObj})";
+    }
+}

--- a/EcoCivicsImportExportMod/Migrations/ICivicsImpExpMigratorV1.cs
+++ b/EcoCivicsImportExportMod/Migrations/ICivicsImpExpMigratorV1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+
+namespace Eco.Mods.CivicsImpExp
+{
+    public interface ICivicsImpExpMigratorV1
+    {
+        bool ShouldMigrate(JObject obj);
+
+        bool ApplyMigration(JObject obj, IList<string> outMigrationReport);
+    }
+}

--- a/EcoCivicsImportExportMod/Migrations/MigratorV1.cs
+++ b/EcoCivicsImportExportMod/Migrations/MigratorV1.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+using Newtonsoft.Json.Linq;
+
+namespace Eco.Mods.CivicsImpExp.Migrations
+{
+    using Shared.Utils;
+
+    public class MigratorV1 : ICivicsImpExpMigratorV1
+    {
+        private static IEnumerable<ICivicsImpExpMigratorV1> InternalMigrators
+            => typeof(ICivicsImpExpMigratorV1).ConcreteTypesWithInteface()
+                .Except(new Type[] { typeof(MigratorV1), typeof(ExternalMigratorV1) })
+                .Select(t => Activator.CreateInstance(t) as ICivicsImpExpMigratorV1);
+
+        private static IEnumerable<ICivicsImpExpMigratorV1> ExternalMigrators
+            => AppDomain.CurrentDomain.GetAssemblies()
+                .FilteredAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Where(t => t.GetInterface("ICivicsImpExpMigratorV1") != null && !t.IsAssignableTo(typeof(ICivicsImpExpMigratorV1)))
+                .Select(t => new ExternalMigratorV1(Activator.CreateInstance(t)));
+
+        private readonly IEnumerable<ICivicsImpExpMigratorV1> allMigrators = ExternalMigrators.Concat(InternalMigrators);
+
+        public bool ShouldMigrate(JObject obj)
+        {
+            foreach (var migrator in allMigrators)
+            {
+                if (migrator.ShouldMigrate(obj))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public bool ApplyMigration(JObject obj, IList<string> outMigrationReport)
+        {
+            bool didMigrate = false;
+            foreach (var migrator in allMigrators)
+            {
+                if (migrator.ShouldMigrate(obj))
+                {
+                    didMigrate |= migrator.ApplyMigration(obj, outMigrationReport);
+                }
+            }
+            return didMigrate;
+        }
+
+        
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ Once the bundle has been assembled to your satisfaction, simply save it to the s
 5. Find the artifact in `EcoCivicsImportExportMod\bin\{Debug|Release}\net5.0`
 
 ### Linux
-
-1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.4.0-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
+1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.4.3-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
 2. Enter the `EcoCi"vicsImportExportMod` directory and run:
 `dotnet restore`
 `dotnet build`


### PR DESCRIPTION
- Added support for migrations.
  Migrations are applied to the json in-memory before deserialisation. Migrators can be implemented within the mod itself (potentially used later when new versions of Eco introduce breaking changes), or by other mods when they introduce breaking changes. Other mods can do this by copying the `ICivicsImpExpMigratorV1` interface to their own code (no need to directly reference this mod) and implementing that in a constructorless class.