### PR TITLE
stage 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build Mod
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.4.3-beta
-      ECO_BRANCH: release
+      MODKIT_VERSION: 0.9.5.0-beta-staging-2214
+      ECO_BRANCH: staging
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 5.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,8 +9,8 @@ jobs:
   build-mod:
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.4.3-beta
-      ECO_BRANCH: release
+      MODKIT_VERSION: 0.9.5.0-beta-staging-2214
+      ECO_BRANCH: staging
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 5.0

--- a/EcoCivicsImportExportMod/CivicBundle.cs
+++ b/EcoCivicsImportExportMod/CivicBundle.cs
@@ -196,15 +196,31 @@ namespace Eco.Mods.CivicsImpExp
             {
                 foreach (var civic in Civics)
                 {
-                    importContext.ImportStub(civic);
-                    foreach (var inlineCivic in civic.InlineObjects)
+                    try
                     {
-                        importContext.ImportStub(inlineCivic);
+                        importContext.ImportStub(civic);
+                        foreach (var inlineCivic in civic.InlineObjects)
+                        {
+                            importContext.ImportStub(inlineCivic);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Failed to import stub for civic {civic.AsReference}: {ex}");
+                        throw;
                     }
                 }
                 foreach (var civic in Civics)
                 {
-                    importContext.Import(civic);
+                    try
+                    {
+                        importContext.Import(civic);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Failed to import civic {civic.AsReference}: {ex}");
+                        throw;
+                    }
                 }
             }
             catch

--- a/EcoCivicsImportExportMod/CivicBundle.cs
+++ b/EcoCivicsImportExportMod/CivicBundle.cs
@@ -22,7 +22,7 @@ namespace Eco.Mods.CivicsImpExp
         }
 
         public IHasID Resolve()
-            => Registrars.Get(Type).GetByName(Name);
+            => Registrars.GetByDerivedType(Type).GetByName(Name);
 
         public override bool Equals(object obj)
             => obj is CivicReference reference && Equals(reference);
@@ -111,7 +111,7 @@ namespace Eco.Mods.CivicsImpExp
 
         public IHasID CreateStub()
         {
-            var registrar = Registrars.Get(Type);
+            var registrar = Registrars.GetByDerivedType(Type);
             if (registrar == null)
             {
                 throw new InvalidOperationException($"No registrar found for type '{Type.FullName}'");

--- a/EcoCivicsImportExportMod/CivicsImpExpPlugin.cs
+++ b/EcoCivicsImportExportMod/CivicsImpExpPlugin.cs
@@ -155,12 +155,12 @@ namespace Eco.Mods.CivicsImpExp
                 }
                 else
                 {
-                    user.Player.Msg(new LocString($"Succesfully exported {successCount} of {civicKey}, but failed to export {failCount} of {civicKey}"));
+                    user.Player.Msg(new LocString($"successfully exported {successCount} of {civicKey}, but failed to export {failCount} of {civicKey}"));
                 }
             }
             else
             {
-                user.Player.Msg(new LocString($"Succesfully exported all {successCount} of {civicKey}"));
+                user.Player.Msg(new LocString($"successfully exported all {successCount} of {civicKey}"));
             }
         }
 
@@ -190,12 +190,12 @@ namespace Eco.Mods.CivicsImpExp
                 }
                 else
                 {
-                    user.Player.Msg(new LocString($"Succesfully exported {successCount} civic objects, but failed to export {failCount} of civic objects"));
+                    user.Player.Msg(new LocString($"successfully exported {successCount} civic objects, but failed to export {failCount} of civic objects"));
                 }
             }
             else
             {
-                user.Player.Msg(new LocString($"Succesfully exported all {successCount} civic objects"));
+                user.Player.Msg(new LocString($"successfully exported all {successCount} civic objects"));
             }
         }
 
@@ -249,7 +249,7 @@ namespace Eco.Mods.CivicsImpExp
             catch (Exception ex)
             {
                 user.Player.Msg(new LocString($"Failed to import bundle: {ex.Message}"));
-                Logger.Error(ex.ToString());
+                Logger.Error($"Exception while importing from '{source}': {ex}");
                 return;
             }
 
@@ -294,7 +294,6 @@ namespace Eco.Mods.CivicsImpExp
             catch (Exception ex)
             {
                 user.Player.Msg(new LocString($"Failed to import civic: {ex.Message}"));
-                Logger.Error(ex.ToString());
                 return;
             }
             lastImport.Clear();

--- a/EcoCivicsImportExportMod/CivicsJsonConverter.cs
+++ b/EcoCivicsImportExportMod/CivicsJsonConverter.cs
@@ -302,9 +302,7 @@ namespace Eco.Mods.CivicsImpExp
             var jsonObj = new JObject();
             jsonObj.Add(new JProperty("type", "GameValueContext"));
             jsonObj.Add(new JProperty("contextName", SerialiseValue(gameValueContext.ContextName)));
-            string titleBacking = gameValueContext.GetType().GetProperty("TitleBacking", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(gameValueContext, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null) as string;
-            jsonObj.Add(new JProperty("titleBacking", SerialiseValue(titleBacking)));
-            string tooltip = gameValueContext.GetType().GetProperty("Tooltip", BindingFlags.Public | BindingFlags.Instance).GetValue(gameValueContext, BindingFlags.Public | BindingFlags.Instance, null, null, null) as string;
+            string tooltip = gameValueContext.GetType().GetProperty("ContextDescription", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(gameValueContext, BindingFlags.Public | BindingFlags.Instance, null, null, null) as string;
             jsonObj.Add(new JProperty("tooltip", SerialiseValue(tooltip)));
             return jsonObj;
         }

--- a/EcoCivicsImportExportMod/ImportContext.cs
+++ b/EcoCivicsImportExportMod/ImportContext.cs
@@ -170,7 +170,7 @@ namespace Eco.Mods.CivicsImpExp
         public object ResolveReference(CivicReference civicReference)
         {
             if (ReferenceMap.TryGetValue(civicReference, out IHasID internalObj)) { return internalObj; }
-            var registrar = Registrars.TypeToRegistrar[civicReference.Type];
+            var registrar = Registrars.GetByDerivedType(civicReference.Type);
             if (registrar == null)
             {
                 throw new InvalidOperationException($"Can't resolve reference to a '{civicReference.Type.FullName}' ('{civicReference.Name}') as no registrar was found for that type");
@@ -234,7 +234,7 @@ namespace Eco.Mods.CivicsImpExp
                 target = Activator.CreateInstance(type);
                 if (target is IHasID hasID)
                 {
-                    var registrar = Registrars.Get(type);
+                    var registrar = Registrars.GetByDerivedType(type);
                     registrar.Insert(hasID);
                 }
             }
@@ -254,7 +254,7 @@ namespace Eco.Mods.CivicsImpExp
             {
                 try
                 {
-                    var registrar = Registrars.Get(target.GetType());
+                    var registrar = Registrars.GetByDerivedType(target.GetType());
                     registrar.Rename(target as IHasID, name, true);
                 }
                 catch (Exception ex)

--- a/EcoCivicsImportExportMod/ImportContext.cs
+++ b/EcoCivicsImportExportMod/ImportContext.cs
@@ -359,11 +359,9 @@ namespace Eco.Mods.CivicsImpExp
             }
             var gameValueContext = Activator.CreateInstance(gameValueContextType) as IGameValueContext;
             string contextName = obj.Value<string>("contextName");
-            gameValueContextType.GetProperty("ContextName", BindingFlags.Public | BindingFlags.Instance).SetValue(gameValueContext, contextName, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
-            string titleBacking = obj.Value<string>("titleBacking");
-            gameValueContextType.GetProperty("TitleBacking", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gameValueContext, titleBacking, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
+            gameValueContextType.GetProperty("Name", BindingFlags.Public | BindingFlags.Instance).SetValue(gameValueContext, contextName, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
             string tooltip = obj.Value<string>("tooltip");
-            gameValueContextType.GetProperty("Tooltip", BindingFlags.Public | BindingFlags.Instance).SetValue(gameValueContext, tooltip, BindingFlags.Public | BindingFlags.Instance, null, null, null);
+            gameValueContextType.GetProperty("ContextDescription", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gameValueContext, tooltip, BindingFlags.Public | BindingFlags.Instance, null, null, null);
             (gameValueContext as IController).Changed("Title");
             return gameValueContext;
         }
@@ -388,15 +386,29 @@ namespace Eco.Mods.CivicsImpExp
 
         private GamePickerList DeserialiseGamePickerList(JObject obj, Type expectedType)
         {
-            if (!expectedType.IsAssignableFrom(typeof(GamePickerList)))
+            GamePickerList gamePickerList;
+            if (expectedType.IsConstructedGenericType)
+            {
+                Type innerType = expectedType.GetGenericArguments()[0];
+                Type gamePickerListType = typeof(GamePickerList<>).MakeGenericType(innerType);
+                if (!expectedType.IsAssignableFrom(gamePickerListType))
+                {
+                    throw new InvalidOperationException($"Can't deserialise a '{gamePickerListType.FullName}' into a '{expectedType.FullName}'");
+                }
+                gamePickerList = Activator.CreateInstance(gamePickerListType, new object[] { null }) as GamePickerList;
+            }
+            else if (expectedType.IsAssignableFrom(typeof(GamePickerList)))
+            {
+                gamePickerList = new GamePickerList();
+                JObject mustDeriveType = obj.Value<JObject>("mustDeriveType");
+                if (mustDeriveType != null)
+                {
+                    gamePickerList.MustDeriveType = DeserialiseValueAsType(mustDeriveType, typeof(Type)) as Type;
+                }
+            }
+            else
             {
                 throw new InvalidOperationException($"Can't deserialise a GamePickerList into a '{expectedType.FullName}'");
-            }
-            var gamePickerList = new GamePickerList();
-            JObject mustDeriveType = obj.Value<JObject>("mustDeriveType");
-            if (mustDeriveType != null)
-            {
-                gamePickerList.MustDeriveType = DeserialiseValueAsType(mustDeriveType, typeof(Type)) as Type;
             }
             string requiredTag = obj.Value<string>("requiredTag");
             if (!string.IsNullOrEmpty(requiredTag))

--- a/EcoCivicsImportExportMod/Importer.cs
+++ b/EcoCivicsImportExportMod/Importer.cs
@@ -29,7 +29,7 @@ namespace Eco.Mods.CivicsImpExp
 
         public static void Cleanup(IHasID obj)
         {
-            Registrars.Remove(obj);
+            Registrars.GetByDerivedType(obj.GetType()).Remove(obj);
             if (obj is IHasSubRegistrarEntries hasSubRegistrarEntries)
             {
                 foreach (var subObj in hasSubRegistrarEntries.SubRegistrarEntries)

--- a/EcoCivicsImportExportMod/Migrations/0950/CivicArticle.cs
+++ b/EcoCivicsImportExportMod/Migrations/0950/CivicArticle.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+using Newtonsoft.Json.Linq;
+
+namespace Eco.Mods.CivicsImpExp.Migrations._0950
+{
+    using Shared.Utils;
+
+    public class CivicArticle : ICivicsImpExpMigratorV1
+    {
+        public bool ShouldMigrate(JObject obj)
+        {
+            if (obj.Value<string>("type") != "Eco.Gameplay.Civics.Constitutional.ConstitutionalAmendment") { return false; }
+            var newArticles = obj.Value<JObject>("properties").Value<JArray>("NewArticles");
+            foreach (var article in newArticles)
+            {
+                var properties = article.Value<JObject>("properties");
+                var executors = properties.Value<JObject>("Executors");
+                if (executors == null || executors.Value<string>("type") == "GameValueWrapper") { return true; }
+                var proposers = properties.Value<JObject>("Proposers");
+                if (proposers == null || proposers.Value<string>("type") == "GameValueWrapper") { return true; }
+            }
+            return false;
+        }
+
+        private JObject CreateGamePickerList(string mustDeriveType, IEnumerable<JObject> entries)
+        {
+            var gamePickerListObj = new JObject();
+            gamePickerListObj.Add("type", "GamePickerList");
+            var mustDeriveTypeObj = new JObject();
+            mustDeriveTypeObj.Add("type", "Type");
+            mustDeriveTypeObj.Add("value", mustDeriveType);
+            gamePickerListObj.Add("mustDeriveType", mustDeriveTypeObj);
+            gamePickerListObj.Add("requiredTag", null);
+            gamePickerListObj.Add("internalDescription", "Any");
+            var entriesArr = new JArray();
+            foreach (var entry in entries)
+            {
+                entriesArr.Add(entry);
+            }
+            gamePickerListObj.Add("entries", entriesArr);
+            return gamePickerListObj;
+        }
+
+        public bool ApplyMigration(JObject obj, IList<string> outMigrationReport)
+        {
+            var newArticles = obj.Value<JObject>("properties").Value<JArray>("NewArticles");
+            foreach (var article in newArticles)
+            {
+                var properties = article.Value<JObject>("properties");
+                var executors = properties.Value<JObject>("Executors");
+                if (executors == null || executors.Value<string>("type") == "GameValueWrapper")
+                {
+                    var newExecutors = CreateGamePickerList("Eco.Gameplay.Alias.IAlias", executors != null ? new JObject[]
+                    {
+                        executors.Value<JObject>("value")
+                    } : Enumerable.Empty<JObject>());
+                    properties.Remove("Executors");
+                    properties.Add("Executors", newExecutors);
+                    outMigrationReport.Add($"Replaced a Executors {(executors == null ? "null" : "GameValueWrapper<IAlias>")} with a GameValuePicker in a civic article of '{obj.Value<string>("name")}'");
+                }
+                var proposers = properties.Value<JObject>("Proposers");
+                if (proposers == null || proposers.Value<string>("type") == "GameValueWrapper")
+                {
+                    var newProposers = CreateGamePickerList("Eco.Gameplay.Alias.IAlias", proposers != null ? new JObject[]
+                    {
+                        proposers.Value<JObject>("value")
+                    } : Enumerable.Empty<JObject>());
+                    properties.Remove("Proposers");
+                    properties.Add("Proposers", newProposers);
+                    outMigrationReport.Add($"Replaced a Proposers {(proposers == null ? "null" : "GameValueWrapper<IAlias>")} with a GameValuePicker in a civic article of '{obj.Value<string>("name")}'");
+                }
+            }
+            return false;
+        }
+
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Eco Civics Import Export Mod
-A server mod for Eco 9.4 that allows admins to export the supported civics (listed below) from a server to json files, where they can be copied to another server and re-imported.
+A server mod for Eco 9.5 that allows admins to export the supported civics (listed below) from a server to json files, where they can be copied to another server and re-imported.
 
 Supported objects:
 - Laws
@@ -133,7 +133,7 @@ Once the bundle has been assembled to your satisfaction, simply save it to the s
 5. Find the artifact in `EcoCivicsImportExportMod\bin\{Debug|Release}\net5.0`
 
 ### Linux
-1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.4.3-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
+1. Run `ECO_BRANCH="staging" MODKIT_VERSION="0.9.5.0-beta-staging-2214" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
 2. Enter the `EcoCi"vicsImportExportMod` directory and run:
 `dotnet restore`
 `dotnet build`


### PR DESCRIPTION
- Updated to Eco 0.9.5.0
- Added more context to import failed error message in server console

Note that there some changes to the civic properties between 0.9.4.x and 0.9.5.0. These have been addressed on import via migrations. There may be other differences that are not yet known that could cause civics export from <0.9.5.0 to be incompatible with 0.9.5.0, and likewise stuff exported from 0.9.5.0 will probably not be compatible with <0.9.5.0.