### PR TITLE
release 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build Mod
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.0-beta-staging-2419
-      ECO_BRANCH: staging
+      MODKIT_VERSION: 0.9.6.1-beta
+      ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build Mod
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.6-beta
+      MODKIT_VERSION: 0.9.7.2-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build Mod
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.1-beta
+      MODKIT_VERSION: 0.9.6.6-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,8 +9,8 @@ jobs:
   build-mod:
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.0-beta-staging-2419
-      ECO_BRANCH: staging
+      MODKIT_VERSION: 0.9.6.1-beta
+      ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 6.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
   build-mod:
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.1-beta
+      MODKIT_VERSION: 0.9.6.6-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
   build-mod:
     runs-on: ubuntu-latest
     env:
-      MODKIT_VERSION: 0.9.6.6-beta
+      MODKIT_VERSION: 0.9.7.2-beta
       ECO_BRANCH: release
     steps:
     - uses: actions/checkout@v2

--- a/EcoCivicsImportExportMod/Exporter.cs
+++ b/EcoCivicsImportExportMod/Exporter.cs
@@ -14,7 +14,7 @@ namespace Eco.Mods.CivicsImpExp
     {
         private static readonly HttpClient httpClient = new HttpClient();
 
-        public static async Task Export(IHasID civicObject, string destination)
+        public static async Task Export(IHasUniversalID civicObject, string destination)
         {
             string text = JsonConvert.SerializeObject(civicObject, Formatting.Indented, new CivicsJsonConverter());
             if (Uri.TryCreate(destination, UriKind.Absolute, out Uri uri))

--- a/EcoCivicsImportExportMod/Migrations/MigratorV1.cs
+++ b/EcoCivicsImportExportMod/Migrations/MigratorV1.cs
@@ -19,8 +19,8 @@ namespace Eco.Mods.CivicsImpExp.Migrations
                 .Select(t => Activator.CreateInstance(t) as ICivicsImpExpMigratorV1);
 
         private static IEnumerable<ICivicsImpExpMigratorV1> ExternalMigrators
-            => AppDomain.CurrentDomain.GetAssemblies()
-                .FilteredAssemblies()
+            => ReflectionUtils
+                .GetGameAssemblies()
                 .SelectMany(a => a.GetTypes())
                 .Where(t => t.GetInterface("ICivicsImpExpMigratorV1") != null && !t.IsAssignableTo(typeof(ICivicsImpExpMigratorV1)))
                 .Select(t => new ExternalMigratorV1(Activator.CreateInstance(t)));

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Eco Civics Import Export Mod
-A server mod for Eco 9.6 that allows admins to export the supported civics (listed below) from a server to json files, where they can be copied to another server and re-imported.
+A server mod for Eco 9.7 that allows admins to export the supported civics (listed below) from a server to json files, where they can be copied to another server and re-imported.
 
 Supported objects:
 - Laws
@@ -23,8 +23,8 @@ All chat commands require admin privileges.
 ### Exporting Civics
 The `export` command will serialise the specific civic object to a json file in the server's working directory, under a folder called `civics`.
 
-`/civics export <civictype>,<id>`
-e.g. `/civics export law,10`
+`/civics export <id>`
+e.g. `/civics export 10`
 
 To find the ID of a civic, tag it in chat and hover it, the ID is displayed at the bottom of the popup.
 `civictype` must be one of:
@@ -133,7 +133,7 @@ Once the bundle has been assembled to your satisfaction, simply save it to the s
 5. Find the artifact in `EcoCivicsImportExportMod\bin\{Debug|Release}\net6.0`
 
 ### Linux
-1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.6.1-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
+1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.7.2-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
 2. Enter the `EcoCivicsImportExportMod` directory and run:
 `dotnet restore`
 `dotnet build`

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Once the bundle has been assembled to your satisfaction, simply save it to the s
 5. Find the artifact in `EcoCivicsImportExportMod\bin\{Debug|Release}\net6.0`
 
 ### Linux
-1. Run `ECO_BRANCH="staging" MODKIT_VERSION="0.9.6.0-beta-staging-2356" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
+1. Run `ECO_BRANCH="release" MODKIT_VERSION="0.9.6.1-beta" fetch-eco-reference-assemblies.sh` (change the modkit branch and version as needed)
 2. Enter the `EcoCivicsImportExportMod` directory and run:
 `dotnet restore`
 `dotnet build`


### PR DESCRIPTION
- Updated to Eco 0.9.7.2-beta
- Changed `/civics export` command to no longer  require a civic type (now it's just `/civics export <id>`)